### PR TITLE
feat: Added support for AzureDevOps

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,8 +7,6 @@ linters-settings:
   funlen:
     lines: 100
     statements: 50
-  gci:
-    local-prefixes: github.com/golangci/golangci-lint
   goconst:
     min-len: 2
     min-occurrences: 2
@@ -27,22 +25,21 @@ linters-settings:
       - wrapperFunc
   gocyclo:
     min-complexity: 15
-  golint:
-    min-confidence: 0
-  gomnd:
-    settings:
-      mnd:
-        # don't include the "operation" and "assign"
-        checks: ["argument","case","condition","return"]
+  mnd:
+    checks:
+      - argument
+      - case
+      - condition
+      - return
   govet:
-    check-shadowing: true
-    fieldalignment: true
+    enable-all: true
+    disable:
+      - fieldalignment
   lll:
     line-length: 140
   misspell:
     locale: US
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
     allow-unused: false # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: false # don't require nolint directives to be specific about which linter is being skipped
@@ -58,20 +55,15 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
-    # - cyclop
     - decorder
-    # - depguard
     - dogsled
-    # - dupl
     - dupword
     - durationcheck
     - errcheck
     - errchkjson
     - errname
     - errorlint
-    - execinquery
     - exhaustive
-    # - exhaustruct
     - exportloopref
     - forbidigo
     - forcetypeassert
@@ -79,20 +71,17 @@ linters:
     - gci
     - ginkgolinter
     - gocheckcompilerdirectives
-    # - gochecknoglobals
-    # - gochecknoinits
-    # - gocognit
     - goconst
     - gocritic
     - gocyclo
     - godot
     - godox
-    - goerr113
+    - err113
     - gofmt
     - gofumpt
     - goheader
     - goimports
-    - gomnd
+    - mnd
     - gomoddirectives
     - gomodguard
     - goprintffuncname
@@ -103,7 +92,6 @@ linters:
     - importas
     - ineffassign
     - interfacebloat
-    # - ireturn
     - lll
     - loggercheck
     - maintidx
@@ -111,7 +99,6 @@ linters:
     - misspell
     - musttag
     - nakedret
-    # - nestif
     - nilerr
     - nilnil
     - nlreturn
@@ -129,7 +116,6 @@ linters:
     - sqlclosecheck
     - staticcheck
     - stylecheck
-    # - tagliatelle
     - tenv
     - testableexamples
     - testpackage
@@ -143,7 +129,6 @@ linters:
     - varnamelen
     - wastedassign
     - whitespace
-    # - wrapcheck
     - wsl
 
 service:

--- a/core/convcom.go
+++ b/core/convcom.go
@@ -16,15 +16,15 @@ type SemanticVersionComponent int
 // GetVersionUpdate determines the version update type (MAJOR, MINOR, PATCH) based on the conventional commit message.
 func GetVersionUpdate(commitMessage string) SemanticVersionComponent {
 	// Regular expression to match commit types, including optional ! before :
-	re := regexp.MustCompile(`^(feat|fix|chore|docs|style|refactor|perf|test|BREAKING CHANGE)(!?)(\(.*\))?: .*`)
+	re := regexp.MustCompile(`^(Merged PR \d+: )?(feat|fix|chore|docs|style|refactor|perf|test|BREAKING CHANGE)(!?)(\(.*\))?: .*`)
 
 	// Extract the commit type from the commit message
 	match := re.FindStringSubmatch(commitMessage)
-	if len(match) > 1 {
-		commitType := match[1]
+	if len(match) > 2 {
+		commitType := match[2]
 
 		// Check if the commit message contains "BREAKING CHANGE:" or has ! in the type
-		if strings.Contains(commitMessage, "BREAKING CHANGE") || (len(match) > 2 && match[2] == "!") {
+		if strings.Contains(commitMessage, "BREAKING CHANGE") || (len(match) > 3 && match[3] == "!") {
 			return MAJOR
 		}
 

--- a/core/convcom.go
+++ b/core/convcom.go
@@ -12,8 +12,10 @@ const (
 )
 
 const (
-	commitTypeGroup     = 2
-	breakingChangeGroup = 3
+	commitTypeGroup                 = 2
+	breakingChangeGroup             = 3
+	lenghtOfMatch                   = 2
+	lenghtOfMatchWithBreakingChange = 3
 )
 
 type SemanticVersionComponent int
@@ -25,11 +27,12 @@ func GetVersionUpdate(commitMessage string) SemanticVersionComponent {
 
 	// Extract the commit type from the commit message
 	match := re.FindStringSubmatch(commitMessage)
-	if len(match) > 2 {
+	if len(match) > lenghtOfMatch {
 		commitType := match[commitTypeGroup]
 
 		// Check if the commit message contains "BREAKING CHANGE:" or has ! in the type
-		if strings.Contains(commitMessage, "BREAKING CHANGE") || (len(match) > 3 && match[breakingChangeGroup] == "!") {
+		if strings.Contains(commitMessage, "BREAKING CHANGE") ||
+			(len(match) > lenghtOfMatchWithBreakingChange && match[breakingChangeGroup] == "!") {
 			return MAJOR
 		}
 

--- a/core/convcom.go
+++ b/core/convcom.go
@@ -11,6 +11,11 @@ const (
 	PATCH
 )
 
+const (
+	commitTypeGroup     = 2
+	breakingChangeGroup = 3
+)
+
 type SemanticVersionComponent int
 
 // GetVersionUpdate determines the version update type (MAJOR, MINOR, PATCH) based on the conventional commit message.
@@ -21,10 +26,10 @@ func GetVersionUpdate(commitMessage string) SemanticVersionComponent {
 	// Extract the commit type from the commit message
 	match := re.FindStringSubmatch(commitMessage)
 	if len(match) > 2 {
-		commitType := match[2]
+		commitType := match[commitTypeGroup]
 
 		// Check if the commit message contains "BREAKING CHANGE:" or has ! in the type
-		if strings.Contains(commitMessage, "BREAKING CHANGE") || (len(match) > 3 && match[3] == "!") {
+		if strings.Contains(commitMessage, "BREAKING CHANGE") || (len(match) > 3 && match[breakingChangeGroup] == "!") {
 			return MAJOR
 		}
 

--- a/core/convcom_test.go
+++ b/core/convcom_test.go
@@ -106,3 +106,33 @@ func Test_GetVersionUpdate_BreakingChangePrefixShouldChangeMayor(t *testing.T) {
 	assert.Equal(t, expectedUpdate, result,
 		"Unexpected version update for refactor update.")
 }
+
+func Test_GetVersionUpdate_AzureDevOpsPrefixFeatPrefixShouldChangeMinor(t *testing.T) {
+	t.Parallel()
+
+	commitMessage := "Merged PR 12345: feat: improve code"
+	expectedUpdate := core.MINOR
+	result := core.GetVersionUpdate(commitMessage)
+	assert.Equal(t, expectedUpdate, result,
+		"Unexpected version update for feat update.")
+}
+
+func Test_GetVersionUpdate_AzureDevOpsPrefixPatchPrefixShouldChangePatch(t *testing.T) {
+	t.Parallel()
+
+	commitMessage := "Merged PR 12345: fix: improve code"
+	expectedUpdate := core.PATCH
+	result := core.GetVersionUpdate(commitMessage)
+	assert.Equal(t, expectedUpdate, result,
+		"Unexpected version update for patch update.")
+}
+
+func Test_GetVersionUpdate_AzureDevOpsPrefixBreakingChangePrefixShouldChangeMayor(t *testing.T) {
+	t.Parallel()
+
+	commitMessage := "Merged PR 12345: BREAKING CHANGE: improve code"
+	expectedUpdate := core.MAJOR
+	result := core.GetVersionUpdate(commitMessage)
+	assert.Equal(t, expectedUpdate, result,
+		"Unexpected version update for refactor update.")
+}

--- a/go.sum
+++ b/go.sum
@@ -15,7 +15,6 @@ github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7N
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
-github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
@@ -73,8 +72,6 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.2.2 h1:Iug2P4fLmDw9f41PB6thxUkNUkJzB5i+1/exaj40L3A=
 github.com/skeema/knownhosts v1.2.2/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
-github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
-github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/integration-tests/calculate.bats
+++ b/integration-tests/calculate.bats
@@ -133,3 +133,36 @@ load 'common.sh'
   assert_equal "1.0" $(echo $output | jq -r .floating_version_minor)
   assert_equal "1.0.1" $(echo $output | jq -r .next_version)
 }
+
+@test "Azure DevOps merge commit for a patch" {
+  create_repository
+  update_repository && tag_repository "v1.0.0"
+  update_repository "fix" "Merged PR 12345: "
+  run $BINARY_PATH calculate --path .tmp/repository --add-floating-tags
+  assert_success
+  assert_equal "1" $(echo $output | jq -r .floating_version_major)
+  assert_equal "1.0" $(echo $output | jq -r .floating_version_minor)
+  assert_equal "1.0.1" $(echo $output | jq -r .next_version)
+}
+
+@test "Azure DevOps merge commit for a breaking change" {
+  create_repository
+  update_repository && tag_repository "v1.0.0"
+  update_repository "BREAKING CHANGE" "Merged PR 12345: "
+  run $BINARY_PATH calculate --path .tmp/repository --add-floating-tags
+  assert_success
+  assert_equal "2" $(echo $output | jq -r .floating_version_major)
+  assert_equal "2.0" $(echo $output | jq -r .floating_version_minor)
+  assert_equal "2.0.0" $(echo $output | jq -r .next_version)
+}
+
+@test "Azure DevOps merge commit for a breaking change with factorial" {
+  create_repository
+  update_repository && tag_repository "v1.0.0"
+  update_repository "refactor!" "Merged PR 12345: "
+  run $BINARY_PATH calculate --path .tmp/repository --add-floating-tags
+  assert_success
+  assert_equal "2" $(echo $output | jq -r .floating_version_major)
+  assert_equal "2.0" $(echo $output | jq -r .floating_version_minor)
+  assert_equal "2.0.0" $(echo $output | jq -r .next_version)
+}

--- a/integration-tests/common.sh
+++ b/integration-tests/common.sh
@@ -36,13 +36,14 @@ create_repository() {
 update_repository() {
   BASE=$PWD
   CHANGE_TYPE=$1
+  PREFIX=$2
   if [ "$1" = "" ]; then
     CHANGE_TYPE="feat"
   fi
   cd .tmp/repository
   date >> file.txt
   git add file.txt
-  git commit -m "$CHANGE_TYPE: Update file.txt"
+  git commit -m "${PREFIX}${CHANGE_TYPE}: Update file.txt"
   cd $BASE
 }
 


### PR DESCRIPTION
Squash commits in Azure DevOps might include a prefix with the pull request number for example: 

<img width="1019" alt="Screenshot 2024-09-02 at 12 04 29" src="https://github.com/user-attachments/assets/6541fd08-cd87-4366-9044-22917e51bafe">

To calculate the semantic version using the conventional commit standard this prefix has to be omitted

This pull request incudes: 

* Added new integration tests that make sure that this new feature works
* Current unit tests passed
* New unit tests were added for this new case 